### PR TITLE
fix MC tester to wait correct number of cycles during output phase

### DIFF
--- a/src/test/scala/hw4/MatMulTester.scala
+++ b/src/test/scala/hw4/MatMulTester.scala
@@ -167,6 +167,9 @@ class MatMulMCTester extends AnyFlatSpec with ChiselScalatestTester {
         dut.io.outBlock.bits.zip(cChunk).foreach{ case (dutIO, elem) => dutIO.expect(elem.S) }
         dut.clock.step()
       }
+      if(cyclesPerTransfer > cChunked.length) {
+        dut.clock.step(cyclesPerTransfer - cChunked.length)
+      }
       dut.io.in.ready.expect(true.B)
     }
     true


### PR DESCRIPTION
Without this, the first MC test case fails to fulfill this requirement and instead expects output for only one cycle:

> Output the result - as soon as the multiplication finishes, the MatMul unit outputs the product matrix over cyclesPerTransfer (via io.outBlock.bits) cycles while asserting io.outBlock.valid